### PR TITLE
Fix problem assessing the truthyness of the "boolean" prevalues

### DIFF
--- a/Tabulate/App_Plugins/Tabulate/Backoffice/controllers/tabulate.controller.js
+++ b/Tabulate/App_Plugins/Tabulate/Backoffice/controllers/tabulate.controller.js
@@ -9,7 +9,7 @@
         assetsService.loadCss(`${basePath}style.min.css`);
 
         // hide the umbraco label if the view is set to wide
-        $scope.model.hideLabel = $scope.model.config.wide;
+        $scope.model.hideLabel = $scope.model.config.wide == true;
         const rteConfig = $scope.model.config.rte;
 
         // these don't need to be scoped
@@ -413,7 +413,7 @@
         $q.all(promises) 
             .then(resp => {
                 this.mapsLoaded = resp[0];
-                this.hideSettings = resp[1].userGroups.indexOf('admin') === -1 && $scope.model.config.adminOnly;
+                this.hideSettings = resp[1].userGroups.indexOf('admin') === -1 && $scope.model.config.adminOnly == true;
 
                 init();
             });

--- a/Tabulate/App_Plugins/Tabulate/Backoffice/views/tabulate.html
+++ b/Tabulate/App_Plugins/Tabulate/Backoffice/views/tabulate.html
@@ -1,4 +1,4 @@
-﻿<div class="tabulate" ng-controller="Tabulate.Controller as vm" ng-class="{'no-settings': vm.noConfig, 'wide' : model.config.wide}">
+﻿<div class="tabulate" ng-controller="Tabulate.Controller as vm" ng-class="{'no-settings': vm.noConfig, 'wide' : model.config.wide == true}">
     
     <umb-editor-sub-header appearance="white">
         <umb-editor-sub-header-content-left ng-show="model.value.data.length > model.value.settings.numPerPage">


### PR DESCRIPTION
The problem we were experiencing is that the "Wide" and "Admin Only" prevalue settings were always coming back as true. Our sites were stuck in "Admin Only Settings" mode. I found that the `adminOnly` and `wide` "boolean" prevalues were coming back with values of `"1"` and `"0"`. `"0"` is a truthy value. I adjusted the logic so that we are comparing them to true which works better.